### PR TITLE
Create reviewer management pages and add/remove reviewers on application dashboard

### DIFF
--- a/mayan/apps/appearance/static/appearance/css/base.css
+++ b/mayan/apps/appearance/static/appearance/css/base.css
@@ -393,6 +393,21 @@ a i {
     color: #f0ad4e;
 }
 
+.btn-danger {
+    background-color: #502c3e !important;
+    border-color: #502c3e !important;
+}
+
+.btn-danger:hover {
+    background-color: #2f1a25 !important;
+    border-color: #1f1118 !important;
+}
+
+.btn-danger:active:focus, .open>.dropdown-toggle.btn-danger:hover, .open>.dropdown-toggle.btn-danger:focus {
+    background-color: #1f1118 !important;
+    border-color: #1f1118 !important;
+}
+
 .btn-danger.btn-outline {
     color: #d9534f;
 }

--- a/mayan/apps/documents/views/application_document_views.py
+++ b/mayan/apps/documents/views/application_document_views.py
@@ -1,7 +1,7 @@
 from django.utils.translation import ugettext_lazy as _
 
-from ..icons import icon_document_recently_created_list
-from ..models.document_models import RecentlyCreatedDocument
+from ..icons import icon_document_list
+from ..models.document_models import Document
 
 from .document_views import DocumentListView
 
@@ -10,13 +10,13 @@ __all__ = ('ApplicationDocumentListView',)
 
 class ApplicationDocumentListView(DocumentListView):
     def get_document_queryset(self):
-        return RecentlyCreatedDocument.recently_created.all()
+        return Document.valid.all()
 
     def get_extra_context(self):
         context = super().get_extra_context()
         context.update(
             {
-                'no_results_icon': icon_document_recently_created_list,
+                'no_results_icon': icon_document_list,
                 'no_results_text': _(
                     'This view will list the application documents created '
                     'in the system.'

--- a/mayan/apps/tags/apps.py
+++ b/mayan/apps/tags/apps.py
@@ -27,7 +27,9 @@ from .links import (
     link_document_multiple_tag_multiple_remove,
     link_document_tag_multiple_remove, link_document_tag_multiple_attach, link_tag_create,
     link_tag_delete, link_tag_edit, link_tag_list,
-    link_tag_multiple_delete, link_tag_document_list
+    link_tag_multiple_delete, link_tag_document_list,
+    link_document_multiple_reviewer_multiple_add,
+    link_document_multiple_reviewer_multiple_remove
 )
 from .menus import menu_tags
 from .methods import method_document_get_tags
@@ -173,7 +175,9 @@ class TagsApp(MayanAppConfig):
         menu_multi_item.bind_links(
             links=(
                 link_document_multiple_tag_multiple_attach,
-                link_document_multiple_tag_multiple_remove
+                link_document_multiple_tag_multiple_remove,
+                link_document_multiple_reviewer_multiple_add,
+                link_document_multiple_reviewer_multiple_remove
             ),
             sources=(Document,)
         )

--- a/mayan/apps/tags/forms.py
+++ b/mayan/apps/tags/forms.py
@@ -16,3 +16,15 @@ class TagMultipleSelectionForm(FilteredSelectionForm):
         required = False
         widget_class = TagFormWidget
         widget_attributes = {'class': 'select2-tags'}
+
+class ReviewerMultipleSelectionForm(FilteredSelectionForm):
+    class Media:
+        js = ('tags/js/tags_form.js',)
+
+    class Meta:
+        allow_multiple = True
+        field_name = 'tags'
+        label = _('Reviewers')
+        required = False
+        widget_class = TagFormWidget
+        widget_attributes = {'class': 'select2-tags'}

--- a/mayan/apps/tags/links.py
+++ b/mayan/apps/tags/links.py
@@ -18,9 +18,17 @@ link_document_multiple_tag_multiple_attach = Link(
     icon=icon_document_tag_multiple_attach, text=_('Attach tags'),
     view='tags:multiple_documents_tag_attach'
 )
+link_document_multiple_reviewer_multiple_add = Link(
+    icon=icon_document_tag_multiple_attach, text=_('Add reviewers'),
+    view='tags:multiple_documents_reviewer_add'
+)
 link_document_multiple_tag_multiple_remove = Link(
     icon=icon_document_tag_multiple_remove, text=_('Remove tag'),
     view='tags:multiple_documents_selection_tag_remove'
+)
+link_document_multiple_reviewer_multiple_remove = Link(
+    icon=icon_document_tag_multiple_remove, text=_('Remove reviewer'),
+    view='tags:multiple_documents_selection_reviewer_remove'
 )
 link_document_tag_list = Link(
     args='resolved_object.pk', icon=icon_document_tag_list,

--- a/mayan/apps/tags/urls.py
+++ b/mayan/apps/tags/urls.py
@@ -8,7 +8,10 @@ from .api_views import (
 from .views import (
     DocumentTagListView, TagAttachActionView, TagCreateView,
     TagDeleteActionView, TagEditView, TagListView, TagRemoveActionView,
-    TagDocumentListView
+    TagDocumentListView,
+    DocumentReviewerListView, ReviewerAddActionView, ReviewerCreateView,
+    ReviewerDeleteActionView, ReviewerEditView, ReviewerListView, ReviewerRemoveActionView,
+    ReviewerDocumentListView
 )
 
 urlpatterns = [
@@ -17,8 +20,16 @@ urlpatterns = [
         name='document_tag_list', view=DocumentTagListView.as_view()
     ),
     url(
+        regex=r'^documents/(?P<document_id>\d+)/reviewers/$',
+        name='document_reviewer_list', view=DocumentReviewerListView.as_view()
+    ),
+    url(
         regex=r'^documents/(?P<document_id>\d+)/tags/multiple/attach/$',
         name='tag_attach', view=TagAttachActionView.as_view()
+    ),
+    url(
+        regex=r'^documents/(?P<document_id>\d+)/reviewers/multiple/add/$',
+        name='reviewer_add', view=TagAttachActionView.as_view()
     ),
     url(
         regex=r'^documents/(?P<document_id>\d+)/tags/multiple/remove/$',
@@ -26,35 +37,71 @@ urlpatterns = [
         view=TagRemoveActionView.as_view()
     ),
     url(
+        regex=r'^documents/(?P<document_id>\d+)/reviewers/multiple/remove/$',
+        name='single_document_multiple_reviewer_remove',
+        view=ReviewerRemoveActionView.as_view()
+    ),
+    url(
         regex=r'^documents/multiple/tags/multiple/remove/$',
         name='multiple_documents_selection_tag_remove',
         view=TagRemoveActionView.as_view()
+    ),
+    url(
+        regex=r'^documents/multiple/reviewers/multiple/remove/$',
+        name='multiple_documents_selection_reviewer_remove',
+        view=ReviewerRemoveActionView.as_view()
     ),
     url(
         regex=r'^documents/multiple/tags/multiple/attach/$',
         name='multiple_documents_tag_attach',
         view=TagAttachActionView.as_view()
     ),
+    url(
+        regex=r'^documents/multiple/reviewers/multiple/add/$',
+        name='multiple_documents_reviewer_add',
+        view=ReviewerAddActionView.as_view()
+    ),
     url(regex=r'^tags/$', name='tag_list', view=TagListView.as_view()),
+    url(regex=r'^reviewers/$', name='reviewer_list', view=ReviewerListView.as_view()),
     url(
         regex=r'^tags/create/$', name='tag_create',
         view=TagCreateView.as_view()
+    ),
+    url(
+        regex=r'^reviewers/create/$', name='reviewer_create',
+        view=ReviewerCreateView.as_view()
     ),
     url(
         regex=r'^tags/(?P<tag_id>\d+)/delete/$', name='tag_delete',
         view=TagDeleteActionView.as_view()
     ),
     url(
+        regex=r'^reviewers/(?P<tag_id>\d+)/delete/$', name='reviewer_delete',
+        view=ReviewerDeleteActionView.as_view()
+    ),
+    url(
         regex=r'^tags/(?P<tag_id>\d+)/edit/$', name='tag_edit',
         view=TagEditView.as_view()
+    ),
+    url(
+        regex=r'^reviewers/(?P<tag_id>\d+)/edit/$', name='reviewer_edit',
+        view=ReviewerEditView.as_view()
     ),
     url(
         regex=r'^tags/(?P<tag_id>\d+)/documents/$', name='tag_document_list',
         view=TagDocumentListView.as_view()
     ),
     url(
+        regex=r'^reviewers/(?P<tag_id>\d+)/documents/$', name='reviewer_document_list',
+        view=ReviewerDocumentListView.as_view()
+    ),
+    url(
         regex=r'^tags/multiple/delete/$', name='tag_multiple_delete',
         view=TagDeleteActionView.as_view()
+    ),
+    url(
+        regex=r'^reviewers/multiple/delete/$', name='reviewer_multiple_delete',
+        view=ReviewerDeleteActionView.as_view()
     )
 ]
 

--- a/mayan/apps/tags/views.py
+++ b/mayan/apps/tags/views.py
@@ -317,3 +317,294 @@ class TagRemoveActionView(MultipleObjectFormActionView):
 
             tag._event_actor = self.request.user
             tag.remove_from(document=instance)
+
+class ReviewerAddActionView(MultipleObjectFormActionView):
+    form_class = TagMultipleSelectionForm
+    object_permission = permission_tag_attach
+    pk_url_kwarg = 'document_id'
+    source_queryset = Document.valid
+    success_message_single = _(
+        'Reviewers added to application document "%(object)s" successfully.'
+    )
+    success_message_singular = _(
+        'Reviewers added to %(count)d application document successfully.'
+    )
+    success_message_plural = _(
+        'Reviewers added to %(count)d application documents successfully.'
+    )
+    title_single = _('Add reviewers to application document: %(object)s')
+    title_singular = _('Add reviewers to %(count)d application document.')
+    title_plural = _('Add reviewers to %(count)d application documents.')
+
+    def get_extra_context(self):
+        context = {
+            'submit_label': _('Add'),
+        }
+
+        if self.object_list.count() == 1:
+            context.update(
+                {
+                    'object': self.object_list.first(),
+                }
+            )
+
+        return context
+
+    def get_form_extra_kwargs(self):
+        kwargs = {
+            'help_text': _('Reviewers to be added.'),
+            'permission': permission_tag_attach,
+            'queryset': Tag.objects.all(),
+            'user': self.request.user
+        }
+
+        if self.object_list.count() == 1:
+            kwargs.update(
+                {
+                    'queryset': Tag.objects.exclude(
+                        pk__in=self.object_list.first().tags.all()
+                    )
+                }
+            )
+
+        return kwargs
+
+    def get_post_action_redirect(self):
+        if self.object_list.count() == 1:
+            return reverse(
+                viewname='tags:document_reviewer_list', kwargs={
+                    'document_id': self.object_list.first().pk
+                }
+            )
+        else:
+            return super().get_post_action_redirect()
+
+    def object_action(self, form, instance):
+        for tag in form.cleaned_data['tags']:
+            AccessControlList.objects.check_access(
+                obj=tag, permissions=(permission_tag_attach,),
+                user=self.request.user
+            )
+
+            tag._event_actor = self.request.user
+            tag.attach_to(document=instance)
+
+
+class ReviewerCreateView(SingleObjectCreateView):
+    extra_context = {'title': _('Create reviewer')}
+    fields = ('label', 'color')
+    model = Tag
+    post_action_redirect = reverse_lazy(viewname='tags:reviewer_list')
+    view_permission = permission_tag_create
+
+    def get_instance_extra_data(self):
+        return {
+            '_event_actor': self.request.user
+        }
+
+
+class ReviewerDeleteActionView(MultipleObjectConfirmActionView):
+    error_message = _('Error deleting reviewer "%(instance)s"; %(exception)s')
+    model = Tag
+    object_permission = permission_tag_delete
+    pk_url_kwarg = 'tag_id'
+    post_action_redirect = reverse_lazy(viewname='tags:reviewer_list')
+    success_message_single = _('Reviewer "%(object)s" deleted successfully.')
+    success_message_singular = _('%(count)d reviewer deleted successfully.')
+    success_message_plural = _('%(count)d reviewers deleted successfully.')
+    title_single = _('Delete reviewer: %(object)s.')
+    title_singular = _('Delete the %(count)d selected reviewer.')
+    title_plural = _('Delete the %(count)d selected reviewers.')
+
+    def get_extra_context(self):
+        context = {
+            'delete_view': True,
+            'message': _('Will be removed from all application documents.'),
+        }
+
+        if self.object_list.count() == 1:
+            context.update(
+                {
+                    'object': self.object_list.first(),
+                }
+            )
+
+        return context
+
+    def object_action(self, instance, form=None):
+        instance.delete()
+
+
+class ReviewerEditView(SingleObjectEditView):
+    fields = ('label', 'color')
+    model = Tag
+    object_permission = permission_tag_edit
+    pk_url_kwarg = 'tag_id'
+    post_action_redirect = reverse_lazy(viewname='tags:reviewer_list')
+
+    def get_extra_context(self):
+        return {
+            'object': self.object,
+            'title': _('Edit reviewer: %s') % self.object,
+        }
+
+    def get_instance_extra_data(self):
+        return {
+            '_event_actor': self.request.user
+        }
+
+
+class ReviewerListView(SingleObjectListView):
+    object_permission = permission_tag_view
+    tag_model = Tag
+
+    def get_extra_context(self):
+        return {
+            'hide_link': True,
+            'hide_object': True,
+            'no_results_icon': icon_menu_tags,
+            'no_results_main_link': link_tag_create.resolve(
+                context=RequestContext(request=self.request)
+            ),
+            'no_results_text': _(
+                'Reviewers are users that can be added or '
+                'removed from application documents.'
+            ),
+            'no_results_title': _('No reviewers available'),
+            'title': _('Reviewers'),
+        }
+
+    def get_source_queryset(self):
+        queryset = ModelQueryFields.get(model=self.tag_model).get_queryset()
+        return queryset.filter(pk__in=self.get_tag_queryset())
+
+    def get_tag_queryset(self):
+        return Tag.objects.all()
+
+
+class ReviewerDocumentListView(ExternalObjectViewMixin, DocumentListView):
+    external_object_class = Tag
+    external_object_permission = permission_tag_view
+    external_object_pk_url_kwarg = 'tag_id'
+
+    def get_document_queryset(self):
+        return Document.valid.filter(
+            pk__in=self.get_tag().get_documents(
+                permission=permission_tag_view, user=self.request.user
+            ).values('pk')
+        )
+
+    def get_extra_context(self):
+        context = super().get_extra_context()
+        context.update(
+            {
+                'object': self.get_tag(),
+                'title': _('Application documents with the reviewer: %s') % self.get_tag(),
+            }
+        )
+        return context
+
+    def get_tag(self):
+        return self.external_object
+
+
+class DocumentReviewerListView(ExternalObjectViewMixin, TagListView):
+    external_object_permission = permission_tag_view
+    external_object_pk_url_kwarg = 'document_id'
+    external_object_queryset = Document.valid
+    tag_model = DocumentTag
+
+    def get_extra_context(self):
+        context = super().get_extra_context()
+        context.update(
+            {
+                'hide_link': True,
+                'no_results_main_link': link_document_tag_multiple_attach.resolve(
+                    context=RequestContext(
+                        self.request, {'object': self.external_object}
+                    )
+                ),
+                'no_results_title': _('Application document has no reviewers added'),
+                'object': self.external_object,
+                'title': _(
+                    'Reviewers for application document: %s'
+                ) % self.external_object,
+            }
+        )
+        return context
+
+    def get_tag_queryset(self):
+        return self.external_object.get_tags(
+            permission=permission_tag_view, user=self.request.user
+        )
+
+
+class ReviewerRemoveActionView(MultipleObjectFormActionView):
+    form_class = TagMultipleSelectionForm
+    object_permission = permission_tag_remove
+    pk_url_kwarg = 'document_id'
+    source_queryset = Document.valid
+    success_message_single = _(
+        'Reviewers removed from application document "%(object)s" successfully.'
+    )
+    success_message_singular = _(
+        'Reviewers removed from %(count)d application document successfully.'
+    )
+    success_message_plural = _(
+        'Reviewers removed from %(count)d application documents successfully.'
+    )
+    title_single = _('Remove reviewers from application document: %(object)s')
+    title_singular = _('Remove reviewers from %(count)d application document.')
+    title_plural = _('Remove reviewers from %(count)d application documents.')
+
+    def get_extra_context(self):
+        context = {
+            'submit_icon': icon_document_tag_remove_submit,
+            'submit_label': _('Remove'),
+        }
+
+        if self.object_list.count() == 1:
+            context.update(
+                {
+                    'object': self.object_list.first(),
+                }
+            )
+
+        return context
+
+    def get_form_extra_kwargs(self):
+        kwargs = {
+            'help_text': _('Reviewers to be removed.'),
+            'permission': permission_tag_remove,
+            'queryset': Tag.objects.all(),
+            'user': self.request.user
+        }
+
+        if self.object_list.count() == 1:
+            kwargs.update(
+                {
+                    'queryset': self.object_list.first().tags.all()
+                }
+            )
+
+        return kwargs
+
+    def get_post_action_redirect(self):
+        if self.object_list.count() == 1:
+            return reverse(
+                viewname='tags:document_reviewer_list', kwargs={
+                    'document_id': self.object_list.first().pk
+                }
+            )
+        else:
+            return super().get_post_action_redirect()
+
+    def object_action(self, form, instance):
+        for tag in form.cleaned_data['tags']:
+            AccessControlList.objects.check_access(
+                obj=tag, permissions=(permission_tag_remove,),
+                user=self.request.user
+            )
+
+            tag._event_actor = self.request.user
+            tag.remove_from(document=instance)

--- a/mayan/apps/tags/views.py
+++ b/mayan/apps/tags/views.py
@@ -15,7 +15,7 @@ from mayan.apps.views.generics import (
 )
 from mayan.apps.views.mixins import ExternalObjectViewMixin
 
-from .forms import TagMultipleSelectionForm
+from .forms import TagMultipleSelectionForm, ReviewerMultipleSelectionForm
 from .icons import icon_menu_tags, icon_document_tag_remove_submit
 from .links import link_document_tag_multiple_attach, link_tag_create
 from .models import DocumentTag, Tag
@@ -319,7 +319,7 @@ class TagRemoveActionView(MultipleObjectFormActionView):
             tag.remove_from(document=instance)
 
 class ReviewerAddActionView(MultipleObjectFormActionView):
-    form_class = TagMultipleSelectionForm
+    form_class = ReviewerMultipleSelectionForm
     object_permission = permission_tag_attach
     pk_url_kwarg = 'document_id'
     source_queryset = Document.valid
@@ -540,7 +540,7 @@ class DocumentReviewerListView(ExternalObjectViewMixin, TagListView):
 
 
 class ReviewerRemoveActionView(MultipleObjectFormActionView):
-    form_class = TagMultipleSelectionForm
+    form_class = ReviewerMultipleSelectionForm
     object_permission = permission_tag_remove
     pk_url_kwarg = 'document_id'
     source_queryset = Document.valid


### PR DESCRIPTION
This commit adds the reviewer management pages and the add/remove reviewers options to the bulk actions by reusing the tags system already in Mayan. This also merges in my HW01 changes which is changing the actions buttons from bright red to dark red to improve color contrast.