### PR TITLE
Redirected 'All', 'edit', 'delete' options to reviewer-specific pages

### DIFF
--- a/mayan/apps/tags/apps.py
+++ b/mayan/apps/tags/apps.py
@@ -26,9 +26,9 @@ from .links import (
     link_document_tag_list, link_document_multiple_tag_multiple_attach,
     link_document_multiple_tag_multiple_remove,
     link_document_tag_multiple_remove, link_document_tag_multiple_attach, link_tag_create,
-    link_tag_delete, link_tag_edit, link_tag_list, link_reviewer_create,
-    link_tag_multiple_delete, link_tag_document_list,
-    link_document_multiple_reviewer_multiple_add,
+    link_tag_delete, link_reviewer_delete, link_tag_edit, link_reviewer_edit, link_tag_list, 
+    link_reviewer_create, link_reviewer_list, link_tag_multiple_delete, link_tag_document_list,
+    link_document_multiple_reviewer_multiple_add, 
     link_document_multiple_reviewer_multiple_remove
 )
 from .menus import menu_tags, menu_reviewers
@@ -172,7 +172,7 @@ class TagsApp(MayanAppConfig):
 
         menu_reviewers.bind_links(
             links=(
-                link_tag_list, link_reviewer_create
+                link_reviewer_list, link_reviewer_create
             )
         )
 
@@ -191,9 +191,15 @@ class TagsApp(MayanAppConfig):
         menu_multi_item.bind_links(
             links=(link_tag_multiple_delete,), sources=(Tag,)
         )
+        # menu_object.bind_links(
+        #     links=(
+        #         link_tag_edit, link_tag_delete
+        #     ),
+        #     sources=(Tag,)
+        # )
         menu_object.bind_links(
             links=(
-                link_tag_edit, link_tag_delete
+                link_reviewer_edit, link_reviewer_delete
             ),
             sources=(Tag,)
         )

--- a/mayan/apps/tags/links.py
+++ b/mayan/apps/tags/links.py
@@ -60,10 +60,20 @@ link_tag_delete = Link(
     permissions=(permission_tag_delete,), tags='dangerous',
     text=_('Delete'), view='tags:tag_delete'
 )
+link_reviewer_delete = Link(
+    args='object.id', icon=icon_tag_delete,
+    permissions=(permission_tag_delete,), tags='dangerous',
+    text=_('Delete'), view='tags:reviewer_delete'
+)
 link_tag_edit = Link(
     args='object.id', icon=icon_tag_edit,
     permissions=(permission_tag_edit,), text=_('Edit'),
     view='tags:tag_edit'
+)
+link_reviewer_edit = Link(
+    args='object.id', icon=icon_tag_edit,
+    permissions=(permission_tag_edit,), text=_('Edit'),
+    view='tags:reviewer_edit'
 )
 link_tag_list = Link(
     condition=get_cascade_condition(
@@ -71,6 +81,13 @@ link_tag_list = Link(
         object_permission=permission_tag_view,
     ), icon=icon_tag_list,
     text=_('All'), view='tags:tag_list'
+)
+link_reviewer_list = Link(
+    condition=get_cascade_condition(
+        app_label='tags', model_name='Tag',
+        object_permission=permission_tag_view,
+    ), icon=icon_tag_list,
+    text=_('All'), view='tags:reviewer_list'
 )
 link_tag_multiple_delete = Link(
     icon=icon_tag_delete, permissions=(permission_tag_delete,),


### PR DESCRIPTION
Previously these options directed to tag pages. Now, they redirect to reviewer pages. Closes #8 .