### PR TITLE
Icon changes for reviewers

### DIFF
--- a/mayan/apps/tags/icons.py
+++ b/mayan/apps/tags/icons.py
@@ -34,3 +34,18 @@ icon_tag_delete_submit = Icon(driver_name='fontawesome', symbol='times')
 icon_tag_edit = Icon(driver_name='fontawesome', symbol='pen')
 icon_tag_document_list = icon_document_list
 icon_tag_list = Icon(driver_name='fontawesome', symbol='tag')
+
+icon_reviewer_list = Icon(
+    driver_name='fontawesome-dual', primary_symbol='user-check',
+    secondary_symbol='clipboard-list'
+)
+icon_reviewer_delete = Icon(driver_name='fontawesome', symbol='user-slash')
+icon_document_multiple_reviewer_multiple_remove = Icon(
+    driver_name='fontawesome', symbol='user-minus'
+)
+icon_document_multiple_reviewer_multiple_attach = Icon(
+    driver_name='fontawesome', symbol='user-plus'
+)
+icon_reviewer_create= Icon(driver_name='fontawesome', symbol='user-plus')
+icon_reviewer_edit= Icon(driver_name='fontawesome', symbol='user-edit')
+icon_menu_reviewers= Icon(driver_name='fontawesome', symbol='user-check')

--- a/mayan/apps/tags/links.py
+++ b/mayan/apps/tags/links.py
@@ -6,7 +6,10 @@ from mayan.apps.navigation.utils import get_cascade_condition
 from .icons import (
     icon_document_tag_multiple_attach, icon_document_tag_multiple_remove,
     icon_document_tag_list, icon_tag_create, icon_tag_delete,
-    icon_tag_document_list, icon_tag_edit, icon_tag_list
+    icon_tag_document_list, icon_tag_edit, icon_tag_list, icon_reviewer_list,
+    icon_reviewer_delete, icon_document_multiple_reviewer_multiple_attach,
+    icon_document_multiple_reviewer_multiple_remove, icon_reviewer_edit,
+    icon_reviewer_create
 )
 from .permissions import (
     permission_tag_attach, permission_tag_create, permission_tag_delete,
@@ -19,7 +22,7 @@ link_document_multiple_tag_multiple_attach = Link(
     view='tags:multiple_documents_tag_attach'
 )
 link_document_multiple_reviewer_multiple_add = Link(
-    icon=icon_document_tag_multiple_attach, text=_('Add reviewers'),
+    icon=icon_document_multiple_reviewer_multiple_attach, text=_('Add reviewers'),
     view='tags:multiple_documents_reviewer_add'
 )
 link_document_multiple_tag_multiple_remove = Link(
@@ -27,7 +30,7 @@ link_document_multiple_tag_multiple_remove = Link(
     view='tags:multiple_documents_selection_tag_remove'
 )
 link_document_multiple_reviewer_multiple_remove = Link(
-    icon=icon_document_tag_multiple_remove, text=_('Remove reviewer'),
+    icon=icon_document_multiple_reviewer_multiple_remove, text=_('Remove reviewer'),
     view='tags:multiple_documents_selection_reviewer_remove'
 )
 link_document_tag_list = Link(
@@ -52,7 +55,7 @@ link_tag_create = Link(
 )
 
 link_reviewer_create = Link(
-    icon=icon_tag_create, permissions=(permission_tag_create,),
+    icon=icon_reviewer_create, permissions=(permission_tag_create,),
     text=_('Create new reviewer'), view='tags:reviewer_create'
 )
 link_tag_delete = Link(
@@ -61,7 +64,7 @@ link_tag_delete = Link(
     text=_('Delete'), view='tags:tag_delete'
 )
 link_reviewer_delete = Link(
-    args='object.id', icon=icon_tag_delete,
+    args='object.id', icon=icon_reviewer_delete,
     permissions=(permission_tag_delete,), tags='dangerous',
     text=_('Delete'), view='tags:reviewer_delete'
 )
@@ -71,7 +74,7 @@ link_tag_edit = Link(
     view='tags:tag_edit'
 )
 link_reviewer_edit = Link(
-    args='object.id', icon=icon_tag_edit,
+    args='object.id', icon=icon_reviewer_edit,
     permissions=(permission_tag_edit,), text=_('Edit'),
     view='tags:reviewer_edit'
 )
@@ -86,7 +89,7 @@ link_reviewer_list = Link(
     condition=get_cascade_condition(
         app_label='tags', model_name='Tag',
         object_permission=permission_tag_view,
-    ), icon=icon_tag_list,
+    ), icon=icon_reviewer_list,
     text=_('All'), view='tags:reviewer_list'
 )
 link_tag_multiple_delete = Link(

--- a/mayan/apps/tags/menus.py
+++ b/mayan/apps/tags/menus.py
@@ -3,7 +3,7 @@ from django.utils.translation import ugettext_lazy as _
 from mayan.apps.navigation.classes import Menu
 from mayan.apps.navigation.utils import get_cascade_condition
 
-from .icons import icon_menu_tags
+from .icons import icon_menu_tags, icon_menu_reviewers
 from .permissions import permission_tag_create, permission_tag_view
 
 menu_tags = Menu(
@@ -15,6 +15,6 @@ menu_tags = Menu(
 )
 
 menu_reviewers = Menu(
-    icon=icon_menu_tags, label=_('Reviewers'),
+    icon=icon_menu_reviewers, label=_('Reviewers'),
     name='reviewers'
 )


### PR DESCRIPTION
Resolves #9 

Adds reviewer logos for every action involving reviewers with custom logos through fontawesome and fontawesome-dual handlers.
![Screen Shot 2021-09-30 at 10 46 20 PM](https://user-images.githubusercontent.com/72578647/135557828-0cccac25-18fd-425c-98af-3b9275d1a5b9.png)
![Screen Shot 2021-09-30 at 10 48 37 PM](https://user-images.githubusercontent.com/72578647/135557899-baa95305-79da-4169-a6df-40d835b7a746.png)


